### PR TITLE
Add an ftplugin/idris2.vim, for filetype-specific settings

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -7,7 +7,7 @@ endif
 setlocal shiftwidth=2
 setlocal tabstop=2
 if exists('g:idris2#allow_tabchar') && g:idris2#allow_tabchar != 0
-	setlocal noexpandtab
+  setlocal noexpandtab
 else
   setlocal expandtab
 endif

--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -1,0 +1,20 @@
+" Based on ftplugin/idris2.vim from https://github.com/edwinb/idris2-vim
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+setlocal shiftwidth=2
+setlocal tabstop=2
+if exists('g:idris2#allow_tabchar') && g:idris2#allow_tabchar != 0
+	setlocal noexpandtab
+else
+  setlocal expandtab
+endif
+
+setlocal comments=s1:{-,mb:-,ex:-},:\|\|\|,:--
+setlocal commentstring=--%s
+setlocal iskeyword+=?
+setlocal wildignore+=*.ibc
+
+let b:did_ftplugin = 1


### PR DESCRIPTION
Edwin's [Idris2-Vim plugin](https://github.com/edwinb/idris2-vim) had a `ftplugin/idris2.vim` file that defined several useful settings for Idris 2 files, such as `'comments'`, `'commentstring'`, and `'shiftwidth'`.

This PR adds a new `ftplugin/idris2.vim` file that contains those useful settings, without all the old command definitions that are now supplanted by LSP operations.

I left in support for the old `g:idris2#allow_tabchar` setting, but I would imagine that approximately 0 people are using it. I am happy to remove it. Those who do really really want `noexpandtab` can set it manually in `after/ftplugin/idris2.vim`.