### PR TITLE
Fix documentation reference.

### DIFF
--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -132,7 +132,7 @@ goto_next()                                       *idris2.metavars.goto_next()*
 `goto_next` tries to jump to the next metavar in the current buffer, cycling
 back to the start if the cursor is after the last metavar.
 
-goto_prev()                                       *idris2.metavars.goto_next()*
+goto_prev()                                       *idris2.metavars.goto_prev()*
 `goto_next` tries to jump to the previous metavar in the current buffer, cycling
 back to the end if the cursor is before the first metavar.
 


### PR DESCRIPTION
I was trying to build it with nix and it threw an error. Was an easy fix though :)

It works now so I think this can be merged.

---

My nix expression for reference:
```nix
(super.vimUtils.buildVimPluginFrom2Nix {
  pname = "idris2";
  version = "2021-12-09";
  src = super.fetchFromGitHub {
    owner = "jumper149";
    repo = "idris2-nvim";
    rev = "e077ca5c3bd2d0f26c758440e21e77262ead52b1";
    sha256 = "SIrN4cgQfD8VPZxjmbypAFN3Z4NomMwNlzxQLoe2wng=";
  };
})
```

---

This was the error message:
```
Sourcing vim-gen-doc-hook
unpacking sources
unpacking source archive /nix/store/mvgkl3ml9j186xk6czdsnf2h3v2yg0nr-source
source root is source
patching sources
configuring
building
installing
post-installation fixup
Executing vimPluginGenTags
Building help tags
Error detected while processing command line:
E154: Duplicate tag "idris2.metavars.goto_next()" in file /nix/store/n2py47hfq6s3y7xvgisljsn0pchqdhb5-vimplugin-idris2-2021-12-09/./doc/idris2-nvim.txtFailed to build help tags!
error: builder for '/nix/store/7ilbxknk7zisi1fifrivna2vdlh0c50b-vimplugin-idris2-2021-12-09.drv' failed with exit code 1;
       last 10 log lines:
       > source root is source
       > patching sources
       > configuring
       > building
       > installing
       > post-installation fixup
       > Executing vimPluginGenTags
       > Building help tags
       > Error detected while processing command line:
       > E154: Duplicate tag "idris2.metavars.goto_next()" in file /nix/store/n2py47hfq6s3y7xvgisljsn0pchqdhb5-vimplugin-idris2-2021-12-09/./doc/idris2-nvim.txtFailed to build help tags!
```