### PR TITLE
support post-code-action hooks.

### DIFF
--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -1,4 +1,4 @@
-*idris2-nvim.txt*   Last change 2021 November 16
+*idris2-nvim.txt*   Last change 2021 December 28
 *idris2.nvim*       Author: ShinKage
                   Repository: https://github.com/ShinKage/idris2-nvim
 
@@ -74,8 +74,21 @@ table expected by the `setup` function, with the default values: >
     server = {}, -- Options passed to lspconfig idris2 configuration
     hover_split_position = 'bottom', -- bottom, top, left or right
     autostart_semantic = true, -- Should start and refresh semantic highlight automatically
+    -- Function to execute after a code action is performed:
+    code_action_post_hook = function(action) end,
   }
 <
+
+If you want to perform some action after the LSP completes a Code Action,
+you can register a hook (a function to be called when any code action is
+completed). 
+
+Your function will be called with the chosen code action as its only parameter.
+This action parameter has a `title` and optionally an `edit`. The details of these
+fields are defined by the Language Server Protocol, but you can use this plugin's
+`introspect_filter()` function to quickly determine what code action was taken
+(see |idris2.code_action.filters| for the possible return values).
+
 ===============================================================================
 API                                                             *idris2-nvim-api*
 
@@ -169,9 +182,18 @@ Before the request asks the user, via an input popup, for the expression to evau
 ===============================================================================
 Lua module: idris2.code_action                               *idris2.code_action*
 
+filters                                           *idris2.code_action.filters*
+`filters` is a list of possible filters to pass to `request_single()` or get
+back from `introspect_filter()`.
+
 request_single({filter})                  *idris2.code_action.request_single()*
 `request_single` is the handler for a single Idris2 LSP Server code action,
 matched by the provided filter.
+
+introspect_filter({action})            *idris2.code_action.introspect_filter()*
+`introspect_filter` returns the filter that categorizes the action passed to
+it. In other words, what filter would have been passed to `request_single()`
+to cause only actions of the given type to be considered.
 
 case_split()                                  *idris2.code_action.case_split()*
 `case_split` requests only a Case Split action from the Idris2 LSP Server.

--- a/lua/idris2/code_action.lua
+++ b/lua/idris2/code_action.lua
@@ -16,6 +16,28 @@ M.filters = {
   REF_HOLE = 'refactor.rewrite.RefineHole',
 }
 
+function M.introspect_filter(action)
+  if string.match(action.title, "Case split") then
+    return M.filters.CASE_SPLIT
+  elseif string.match(action.title, "Make case") then
+    return M.filters.MAKE_CASE
+  elseif string.match(action.title, "Make with") then
+    return M.filters.MAKE_WITH
+  elseif string.match(action.title, "Add clause") then
+    return M.filters.ADD_CLAUSE
+  elseif string.match(action.title, "Make lemma") then
+    return M.filters.MAKE_LEMMA
+  elseif string.match(action.title, "Add clause") then
+    return M.filters.ADD_CLAUSE
+  elseif string.match(action.title, "Expression search") then
+    return M.filters.EXPR_SEARCH
+  elseif string.match(action.title, "Generate definition") then
+    return M.filters.GEN_DEF
+  elseif string.match(action.title, "Refine hole") then
+    return M.filters.REF_HOLE
+  end
+end
+
 local function has_multiple_results(filter)
   return filter == M.filters.EXPR_SEARCH
            or filter == M.filters.GEN_DEF
@@ -165,8 +187,9 @@ function M.setup()
   vim.ui.select = function(action_tuples, opts, on_user_choice)
     local function on_choice(action_tuple)
       on_user_choice(action_tuple)
-      if opts.kind == 'codeaction' then
-	custom_handler(action_tuple[2])
+      if opts.kind == 'codeaction'
+	and action_tuple ~= nil then
+	  custom_handler(action_tuple[2])
       end
     end
     ui_select(action_tuples, opts, on_choice)

--- a/lua/idris2/code_action.lua
+++ b/lua/idris2/code_action.lua
@@ -1,6 +1,8 @@
 local Input = require("nui.input")
 local event = require("nui.utils.autocmd").event
 
+local plugin_config = require('idris2.config')
+
 local M = {}
 
 M.filters = {
@@ -36,6 +38,16 @@ local function single_action_handler(err, result, ctx, config)
   if action.edit ~= nil then
     vim.lsp.util.apply_workspace_edit(action.edit)
   end
+
+  local params = ctx.params
+  if params ~= nil then
+    local filter = ctx.params.context.only[1]
+    local optional_post_hook = plugin_config.options.post_hooks[filter]
+    if optional_post_hook ~= nil then
+      optional_post_hook(err, result, ctx, config)
+    end
+  end
+
 end
 
 function M.request_single(filter)

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   },
   -- opts for nvim-lspconfig
   server = {},
+  post_hooks = {},
   hover_split_position = 'bottom',
   autostart_semantic = true,
 }

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -10,7 +10,6 @@ local defaults = {
   },
   -- opts for nvim-lspconfig
   server = {},
-  post_hooks = {},
   hover_split_position = 'bottom',
   autostart_semantic = true,
 }

--- a/lua/idris2/init.lua
+++ b/lua/idris2/init.lua
@@ -1,6 +1,7 @@
 local config = require('idris2.config')
 local semantic = require('idris2.semantic')
 local hover = require('idris2.hover')
+local code_action = require('idris2.code_action')
 
 local M = {}
 
@@ -69,6 +70,7 @@ function M.setup(options)
   setup_on_attach()
   setup_handlers()
   hover.setup()
+  code_action.setup()
 
   vim.cmd [[highlight link LspSemantic_variable idrisString]]
   vim.cmd [[highlight link LspSemantic_enumMember idrisStructure]]


### PR DESCRIPTION
I will be far from offended if this isn't the direction you want to go with this, but if you do I am also happy to add some documentation for it.

In playing around locally, this works rather well for me and it's extensible, although it doesn't work with "multiple result" actions as-is.

```lua
local filters = require('idris2.code_action').filters

local save_hook = function(err, result, ctx, config)
  vim.cmd('write')
end

local post_hooks = {
  [filters.CASE_SPLIT] = save_hook,
  [filters.MAKE_LEMMA] = save_hook,
  [filters.ADD_CLAUSE] = save_hook
}

require('idris2').setup({
  server = {on_attach = custom_lsp_attach},
  post_hooks = post_hooks
})
```