### PR TITLE
Add a basic repl evaluate command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ vim.cmd [[nnoremap <Leader>cs <Cmd>lua require('idris2.code_action').case_split(
 |-------------|-------------------------------------------------------------------------------------|
 |`browse`     |Asks the user for a namespace and returns the list of names visible in that namespace|
 
+### `idris2.repl` module
+|Function     |Description                                                                              |
+|-------------|-----------------------------------------------------------------------------------------|
+|`evaluate`   |Prompts for an expression that the LSP should evaluate in the context of the current file|
+
 ### `idris2.hover` module
 |Function     |Description                                                    |
 |-------------|---------------------------------------------------------------|

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -160,6 +160,13 @@ for the namespace. The default options are: >
   }
 
 ===============================================================================
+Lua module: idris2.repl                                           *idris2.repl*
+
+evaluate()                                             *idris2.repl.evaluate()*
+`evaluate` sends a request to the LSP to evaluate a given expression.
+Before the request asks the user, via an input popup, for the expression to evaulate.
+
+===============================================================================
 Lua module: idris2.code_action                               *idris2.code_action*
 
 request_single({filter})                  *idris2.code_action.request_single()*

--- a/lua/idris2/repl.lua
+++ b/lua/idris2/repl.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+local Input = require('nui.input')
+local event = require('nui.utils.autocmd').event
+
+local term_popup_options = {
+  relative = "cursor",
+  position = {
+    row = 1,
+    col = 0,
+  },
+  size = 30,
+  border = {
+    style = "rounded",
+    highlight = "FloatBorder",
+    text = {
+      top = "Evaluate",
+      top_align = "left",
+    },
+  },
+  win_options = {
+    winhighlight = "Normal:Normal",
+  },
+}
+
+-- err, result, ctx
+function M.menu_handler(expression)
+  return function (err, result, ctx, config)
+    if err ~= nil then
+      vim.notify(err, vim.log.levels.ERROR)
+    else
+      vim.notify(result, vim.log.levels.INFO)
+    end
+  end
+end
+
+function M.evaluate()
+  local input = Input(term_popup_options, {
+    prompt = '> ',
+    default_value = '',
+    on_submit = function(value)
+      local params = {
+        command = 'repl',
+        arguments = { value },
+      }
+      vim.lsp.buf_request(0, 'workspace/executeCommand', params, M.menu_handler(value))
+    end,
+  })
+  input:mount()
+end
+
+return M


### PR DESCRIPTION
Adds one of the few remaining niceties from the older (non-LSP) vim Idris 2 integration.