### PR TITLE
Use vim.notify and missing err cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ local opts = {
   server = {}, -- Options passed to lspconfig idris2 configuration
   hover_split_position = 'bottom', -- bottom, top, left or right
   autostart_semantic = true, -- Should start and refresh semantic highlight automatically
+  code_action_post_hook = function(action) end, -- Function to execute after a code action is performed:
+  use_default_semantic_hl_groups = true, -- Set default highlight groups for semantic tokens
 }
 require('idris2').setup(opts)
 ```
@@ -91,7 +93,8 @@ end
 ```
 
 ### Semantic Highlighting
-The server uses the regular syntax highlight groups as defaults for semantic highlight groups. Some examples of custom configuration are:
+The server uses the regular syntax highlight groups as defaults for semantic highlight groups, if the option `use_default_semantic_hl_groups` is set to `true`.
+Some examples of custom configuration are:
 
 ```lua
 vim.cmd [[highlight link LspSemantic_type Include]] -- Use the same highlight as the Include group

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -74,8 +74,8 @@ table expected by the `setup` function, with the default values: >
     server = {}, -- Options passed to lspconfig idris2 configuration
     hover_split_position = 'bottom', -- bottom, top, left or right
     autostart_semantic = true, -- Should start and refresh semantic highlight automatically
-    -- Function to execute after a code action is performed:
-    code_action_post_hook = function(action) end,
+    code_action_post_hook = function(action) end, -- Function to execute after a code action is performed:
+    use_default_semantic_hl_groups = true, -- Set default highlight groups for semantic tokens
   }
 <
 

--- a/lua/idris2/browse.lua
+++ b/lua/idris2/browse.lua
@@ -45,8 +45,13 @@ local name_popup_options = {
 function M.menu_handler(ns, opts)
   local opts = opts or {}
   return function (err, result, ctx, config)
+    if err ~= nil then
+      vim.notify(err, vim.log.levels.ERROR)
+      return
+    end
+
     if vim.tbl_isempty(result) then
-      print('No definitions in ' .. ns)
+      vim.notify('No definitions in ' .. ns, vim.log.levels.INFO)
       return
     end
 
@@ -72,7 +77,7 @@ function M.menu_handler(ns, opts)
         if item.entry.location ~= nil then
           vim.lsp.util.jump_to_location(item.entry.location)
         else
-          error('selected name is not in a physical location')
+          vim.notify('Selected name is not in a physical location', vim.log.levels.ERROR)
         end
       end,
     })

--- a/lua/idris2/code_action.lua
+++ b/lua/idris2/code_action.lua
@@ -52,13 +52,18 @@ local function handle_code_action_post_hook(action)
 end
 
 local function single_action_handler(err, result, ctx, config)
+  if err ~= nil then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
+
   if not result or #result == 0 then
     vim.notify('No code actions available', vim.log.levels.INFO)
     return
   end
 
   if #result > 1 then
-    error('Received code action with multiple results')
+    vim.notify('Received code action with multiple results', vim.log.levels.ERROR)
     return
   end
 
@@ -92,6 +97,11 @@ function M.generate_def() M.request_single(M.filters.GEN_DEF)     end
 function M.refine_hole()  M.request_single(M.filters.REF_HOLE)    end
 
 local function on_with_hints_results(err, results, ctx, config)
+  if err ~= nil then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
+
   if not results or #results == 0 then
     vim.notify('No code actions available', vim.log.levels.INFO)
     return
@@ -187,9 +197,8 @@ function M.setup()
   vim.ui.select = function(action_tuples, opts, on_user_choice)
     local function on_choice(action_tuple)
       on_user_choice(action_tuple)
-      if opts.kind == 'codeaction'
-	and action_tuple ~= nil then
-	  custom_handler(action_tuple[2])
+      if opts.kind == 'codeaction' and action_tuple ~= nil then
+        custom_handler(action_tuple[2])
       end
     end
     ui_select(action_tuples, opts, on_choice)

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -12,6 +12,7 @@ local defaults = {
   server = {},
   hover_split_position = 'bottom',
   autostart_semantic = true,
+  use_default_semantic_hl_groups = true,
 }
 
 M.options = {}

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -7,6 +7,10 @@ local M = {}
 M.res_split = nil
 
 function M.handler(err, result, ctx, cfg)
+  if err ~= nil then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
   if not result then
     return
   end
@@ -64,7 +68,7 @@ function M.setup()
   vim.api.nvim_buf_set_name(M.res_split.bufnr, 'Idris2 LSP Response Buffer')
   M.res_split:on({event.BufWinEnter, event.BufEnter}, function()
     if vim.fn.winnr('$') == 1 and vim.api.nvim_get_current_win() == M.res_split.winid then
-      vim.cmd([[q]])
+      vim.cmd [[q]]
     end
   end)
   M.res_split:on({event.BufHidden, event.WinClosed}, function()

--- a/lua/idris2/init.lua
+++ b/lua/idris2/init.lua
@@ -53,7 +53,7 @@ local function setup_lsp()
   -- the function that adds files to the attached LSP instance, so that it
   -- doesn't add Idris2 files in the installation prefix (idris2 --prefix)
   local old_try_add = nvim_lsp.idris2_lsp.manager.try_add
-  local res = vim.split(vim.fn.system({'idris2', '--prefix'}), '\n')[1]
+  local res = vim.split(vim.fn.system({ 'idris2', '--prefix' }), '\n')[1]
   nvim_lsp.idris2_lsp.manager.try_add = function(bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     local path = vim.api.nvim_buf_get_name(bufnr)
@@ -72,14 +72,16 @@ function M.setup(options)
   hover.setup()
   code_action.setup()
 
-  vim.cmd [[highlight link LspSemantic_variable idrisString]]
-  vim.cmd [[highlight link LspSemantic_enumMember idrisStructure]]
-  vim.cmd [[highlight link LspSemantic_function idrisIdentifier]]
-  vim.cmd [[highlight link LspSemantic_type idrisType]]
-  vim.cmd [[highlight link LspSemantic_keyword idrisStatement]]
-  vim.cmd [[highlight link LspSemantic_namespace idrisImport]]
-  vim.cmd [[highlight link LspSemantic_postulate idrisStatement]]
-  vim.cmd [[highlight link LspSemantic_module idrisModule]]
+  if config.use_default_semantic_hl_groups then
+    vim.cmd [[highlight link LspSemantic_variable idrisString]]
+    vim.cmd [[highlight link LspSemantic_enumMember idrisStructure]]
+    vim.cmd [[highlight link LspSemantic_function idrisIdentifier]]
+    vim.cmd [[highlight link LspSemantic_type idrisType]]
+    vim.cmd [[highlight link LspSemantic_keyword idrisStatement]]
+    vim.cmd [[highlight link LspSemantic_namespace idrisImport]]
+    vim.cmd [[highlight link LspSemantic_postulate idrisStatement]]
+    vim.cmd [[highlight link LspSemantic_module idrisModule]]
+  end
 
   setup_lsp()
 end

--- a/lua/idris2/metavars.lua
+++ b/lua/idris2/metavars.lua
@@ -43,8 +43,12 @@ function M.jump_handler(backward)
   end
 
   return function(err, result, ctx, config)
+    if err ~= nil then
+      vim.notify(err, vim.log.levels.ERROR)
+      return
+    end
     if vim.tbl_isempty(result) then
-      print('No metavariables in context')
+      vim.notify('No metavariables in context', vim.log.levels.INFO)
       return
     end
 
@@ -74,8 +78,13 @@ end
 function M.menu_handler(opts)
   local opts = opts or {}
   return function (err, result, ctx, config)
+    if err ~= nil then
+      vim.notify(err, vim.log.levels.ERROR)
+      return
+    end
+
     if vim.tbl_isempty(result) then
-      print('No metavariables in context')
+      vim.notify('No metavariables in context', vim.log.levels.INFO)
       return
     end
 
@@ -100,7 +109,7 @@ function M.menu_handler(opts)
         if item.metavar.location ~= nil then
           vim.lsp.util.jump_to_location(item.metavar.location)
         else
-          error('selected metavar is not in a physical location')
+          vim.notify('Selected metavar is not in a physical location', vim.log.levels.ERROR)
         end
       end,
     })
@@ -113,15 +122,15 @@ function M.menu_handler(opts)
 end
 
 function M.request_all(opts)
-  vim.lsp.buf_request(0, 'workspace/executeCommand', {command = 'metavars'}, M.menu_handler(opts))
+  vim.lsp.buf_request(0, 'workspace/executeCommand', { command = 'metavars' }, M.menu_handler(opts))
 end
 
 function M.goto_next()
-  vim.lsp.buf_request(0, 'workspace/executeCommand', {command = 'metavars'}, M.jump_handler(false))
+  vim.lsp.buf_request(0, 'workspace/executeCommand', { command = 'metavars' }, M.jump_handler(false))
 end
 
 function M.goto_prev()
-  vim.lsp.buf_request(0, 'workspace/executeCommand', {command = 'metavars'}, M.jump_handler(true))
+  vim.lsp.buf_request(0, 'workspace/executeCommand', { command = 'metavars' }, M.jump_handler(true))
 end
 
 return M

--- a/lua/idris2/semantic.lua
+++ b/lua/idris2/semantic.lua
@@ -9,6 +9,10 @@ function M.request(bufnr)
 end
 
 function M.refresh(err, result, ctx, cfg)
+  if err ~= nil then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
   if config.semantic_refresh then
     M.request(ctx.bufnr)
   end
@@ -16,6 +20,11 @@ function M.refresh(err, result, ctx, cfg)
 end
 
 function M.full(err, result, ctx, cfg)
+  if err ~= nil then
+    vim.notify(err, vim.log.levels.ERROR)
+    return
+  end
+
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   local bufnr = ctx.bufnr
   local legend = client.server_capabilities.semanticTokensProvider.legend
@@ -42,7 +51,7 @@ function M.full(err, result, ctx, cfg)
     local byte_end = vim.str_byteindex(line, prev_start + data[i + 2])
     vim.api.nvim_buf_add_highlight(bufnr, ns, 'LspSemantic_' .. token_type, prev_line, byte_start, byte_end)
   end
-  print(vim.fn.expand('%:t') .. ' semantically highlighted')
+  vim.notify(vim.fn.expand('%:t') .. ' semantically highlighted', vim.log.levels.INFO)
 end
 
 function M.clear()


### PR DESCRIPTION
Use `vim.notify` for all messages to be displayed to the user and fix handlers that did not handle erroring messages.
Closes #6.