### PR TITLE
Make hover split size be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ local opts = {
   client = {
     hover = {
       use_split = false, -- Persistent split instead of popups for hover
+      split_size = '30%', -- Size of persistent split, if used
+      auto_resize_split = false, -- Should resize split to use minimum space
       with_history = false, -- Show history of hovers instead of only last
     },
   },

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -68,6 +68,8 @@ table expected by the `setup` function, with the default values: >
     client = {
       hover = {
         use_split = false, -- Persistent split instead of popups for hover
+        split_size = '30%', -- Size of persistent split, if used
+        auto_resize_split = false, -- Should resize split to use minimum space
         with_history = false, -- Show history of hovers instead of only last
       },
     },

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -5,6 +5,8 @@ local defaults = {
   client = {
     hover = {
       use_split = false,
+      split_size = '30%',
+      auto_resize_split = false,
       with_history = false,
     },
   },

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -24,6 +24,7 @@ function M.handler(err, result, ctx, cfg)
     }
     local lines = vim.split(result.contents.value, '\n')
     lines = vim.lsp.util.trim_empty_lines(lines)
+    table.insert(lines, 1, '')
     table.insert(lines, '')
 
     if config.split_history then
@@ -33,6 +34,9 @@ function M.handler(err, result, ctx, cfg)
       vim.api.nvim_win_set_cursor(M.res_split.winid, {count, 0})
     else
       vim.api.nvim_buf_set_lines(M.res_split.bufnr, 0, -1, false, lines)
+      if config.options.client.hover.auto_resize_split then
+        vim.api.nvim_win_set_height(M.res_split.winid, #(lines))
+      end
     end
 
     vim.api.nvim_buf_set_option(M.res_split.bufnr, 'modifiable', false)
@@ -45,7 +49,7 @@ function M.setup()
   M.res_split = Split({
     relative = 'editor',
     position = config.options.hover_split_position,
-    size = '30%',
+    size = config.options.client.hover.split_size,
     focusable = false,
     win_options = {
       foldenable = false,

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -17,17 +17,18 @@ function M.handler(err, result, ctx, cfg)
 
   if config.split_open then
     vim.api.nvim_buf_set_option(M.res_split.bufnr, 'modifiable', true)
-    local prefixlines = {
-      '------------------------------',
-      '-- ' .. vim.fn.strftime('%c') .. ' --',
-      '------------------------------'
-    }
+
     local lines = vim.split(result.contents.value, '\n')
     lines = vim.lsp.util.trim_empty_lines(lines)
     table.insert(lines, 1, '')
     table.insert(lines, '')
 
     if config.split_history then
+      local prefixlines = {
+        '------------------------------',
+        '-- ' .. vim.fn.strftime('%c') .. ' --',
+        '------------------------------'
+      }
       vim.api.nvim_buf_set_lines(M.res_split.bufnr, -1, -1, false, prefixlines)
       vim.api.nvim_buf_set_lines(M.res_split.bufnr, -1, -1, false, lines)
       local count = vim.api.nvim_buf_line_count(M.res_split.bufnr)


### PR DESCRIPTION
Move current hardcoded size to an option. Also, add a config option to resize automatically when buffer is filled. Defaults are set so that behaviour does not change, so this should be a non-breaking change.

Also, a tiny cleanup, movement of one assignment closer to when it's actually used.