### PR TITLE
[ breaking ] Make hover split position be in the hover config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ local opts = {
       use_split = false, -- Persistent split instead of popups for hover
       split_size = '30%', -- Size of persistent split, if used
       auto_resize_split = false, -- Should resize split to use minimum space
+      split_position = 'bottom', -- bottom, top, left or right
       with_history = false, -- Show history of hovers instead of only last
     },
   },
   server = {}, -- Options passed to lspconfig idris2 configuration
-  hover_split_position = 'bottom', -- bottom, top, left or right
   autostart_semantic = true, -- Should start and refresh semantic highlight automatically
   code_action_post_hook = function(action) end, -- Function to execute after a code action is performed:
   use_default_semantic_hl_groups = true, -- Set default highlight groups for semantic tokens

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -70,11 +70,11 @@ table expected by the `setup` function, with the default values: >
         use_split = false, -- Persistent split instead of popups for hover
         split_size = '30%', -- Size of persistent split, if used
         auto_resize_split = false, -- Should resize split to use minimum space
+        split_position = 'bottom', -- bottom, top, left or right
         with_history = false, -- Show history of hovers instead of only last
       },
     },
     server = {}, -- Options passed to lspconfig idris2 configuration
-    hover_split_position = 'bottom', -- bottom, top, left or right
     autostart_semantic = true, -- Should start and refresh semantic highlight automatically
     code_action_post_hook = function(action) end, -- Function to execute after a code action is performed:
     use_default_semantic_hl_groups = true, -- Set default highlight groups for semantic tokens

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -7,12 +7,12 @@ local defaults = {
       use_split = false,
       split_size = '30%',
       auto_resize_split = false,
+      split_position = 'bottom',
       with_history = false,
     },
   },
   -- opts for nvim-lspconfig
   server = {},
-  hover_split_position = 'bottom',
   autostart_semantic = true,
   use_default_semantic_hl_groups = true,
 }

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -49,7 +49,7 @@ end
 function M.setup()
   M.res_split = Split({
     relative = 'editor',
-    position = config.options.hover_split_position,
+    position = config.options.client.hover.split_position,
     size = config.options.client.hover.split_size,
     focusable = false,
     win_options = {


### PR DESCRIPTION
I may misunderstand the reasons why this was done originally, but it all looks like the right place of the configuration option is inside the `client.hover` substructure.

This is a breaking change.