### PR TITLE
Split fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ local opts = {
       auto_resize_split = false, -- Should resize split to use minimum space
       split_position = 'bottom', -- bottom, top, left or right
       with_history = false, -- Show history of hovers instead of only last
+      use_as_popup = false, -- Close the split on cursor movement
     },
   },
   server = {}, -- Options passed to lspconfig idris2 configuration

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -72,6 +72,7 @@ table expected by the `setup` function, with the default values: >
         auto_resize_split = false, -- Should resize split to use minimum space
         split_position = 'bottom', -- bottom, top, left or right
         with_history = false, -- Show history of hovers instead of only last
+        use_as_popup = false, -- Close the split on cursor movement
       },
     },
     server = {}, -- Options passed to lspconfig idris2 configuration

--- a/lua/idris2/config.lua
+++ b/lua/idris2/config.lua
@@ -9,6 +9,7 @@ local defaults = {
       auto_resize_split = false,
       split_position = 'bottom',
       with_history = false,
+      use_as_popup = false,
     },
   },
   -- opts for nvim-lspconfig
@@ -27,7 +28,7 @@ function M.setup(options)
   if M.options.autostart_semantic then
     M.semantic_refresh = true
   end
-  if M.options.client.hover.use_split then
+  if M.options.client.hover.use_split and not M.options.client.hover.use_as_popup then
     M.split_open = true
   end
 end

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -91,8 +91,11 @@ function M.setup()
     config.split_open = false
     M.res_split:hide()
   end)
-  if ft ~= 'idris2' or not config.split_open then
-    M.res_split:hide()
+  M.res_split:hide()
+  if config.options.client.hover.use_split then
+    vim.cmd [[
+      autocmd BufEnter *.idr ++once lua require('idris2.hover').open_split()
+    ]]
   end
 end
 

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -47,6 +47,7 @@ function M.handler(err, result, ctx, cfg)
 end
 
 function M.setup()
+  local ft = vim.bo.filetype
   M.res_split = Split({
     relative = 'editor',
     position = config.options.client.hover.split_position,
@@ -80,7 +81,7 @@ function M.setup()
     config.split_open = false
     M.res_split:hide()
   end)
-  if not config.split_open then
+  if ft ~= 'idris2' or not config.split_open then
     M.res_split:hide()
   end
 end

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -92,7 +92,7 @@ function M.setup()
     M.res_split:hide()
   end)
   M.res_split:hide()
-  if config.options.client.hover.use_split then
+  if config.options.client.hover.use_split and not config.options.client.hover.use_as_popup then
     vim.cmd [[
       autocmd BufEnter *.idr ++once lua require('idris2.hover').open_split()
     ]]

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -15,6 +15,16 @@ function M.handler(err, result, ctx, cfg)
     return
   end
 
+  if config.options.client.hover.use_as_popup and not config.split_open then
+    M.open_split()
+    vim.cmd [[
+      augroup idris2_split_popup
+        autocmd!
+        autocmd CursorMoved,CursorMovedI,InsertCharPre <buffer> ++once lua require('idris2.hover').close_split()
+      augroup end
+    ]]
+  end
+
   if config.split_open then
     vim.api.nvim_buf_set_option(M.res_split.bufnr, 'modifiable', true)
 


### PR DESCRIPTION
- Avoid opening the split panel on non idris2 files
- Add a popup option for the split panel. It behaves the same as the default popup handler, i.e. closing on every cursor movement or insert.