### PR TITLE
Add an ftplugin for ipkg files

### DIFF
--- a/ftplugin/ipkg.vim
+++ b/ftplugin/ipkg.vim
@@ -1,0 +1,9 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+
+setlocal comments=:--
+setlocal commentstring=--%s
+setlocal wildignore+=*.ibc
+
+let b:did_ftplugin = 1


### PR DESCRIPTION
This sets the comment prefix correctly, and adds the same 'wildignore' option.

Without this change, Vim defaults to C-style comments (// and /* */).