### PR TITLE
Add ftplugin for ipkg

### DIFF
--- a/ftplugin/ipkg.vim
+++ b/ftplugin/ipkg.vim
@@ -1,0 +1,9 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+
+setlocal comments=:--
+setlocal commentstring=--%s
+setlocal wildignore+=*.ibc
+
+let b:did_ftplugin = 1


### PR DESCRIPTION
This sets the comment prefix correctly, and adds the same 'wildignore' option.

Without this change, Vim defaults to C-style comments (`//` and `/* */`).

Sorry about the duplicate PR (https://github.com/ShinKage/idris2-nvim/pull/14), I didn't realize Github would close the PR when I changed the branch name.