### PR TITLE
Properly handle semantic token errors

### DIFF
--- a/lua/idris2/semantic.lua
+++ b/lua/idris2/semantic.lua
@@ -21,7 +21,7 @@ end
 
 function M.full(err, result, ctx, cfg)
   if err ~= nil then
-    vim.notify(err, vim.log.levels.ERROR)
+    vim.notify(tostring(err), vim.log.levels.ERROR)
     return
   end
 


### PR DESCRIPTION
Semantic token errors are reported as tables and not plain strings. They implement `__tostring`, so we can use `tostring()` to obtain human-readable error messages.

Without this change, semantic token errors triggered a traceback from `vim.notify` (because the input was not a string), and the actual error was not reported to the user.

This change should be backward-compatible, because `tostring()` is idempotent on strings.