### PR TITLE
Better repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ vim.cmd [[nnoremap <Leader>cs <Cmd>lua require('idris2.code_action').case_split(
 |`browse`     |Asks the user for a namespace and returns the list of names visible in that namespace|
 
 ### `idris2.repl` module
-|Function     |Description                                                                              |
-|-------------|-----------------------------------------------------------------------------------------|
-|`evaluate`   |Prompts for an expression that the LSP should evaluate in the context of the current file|
+|Function         |Description                                                                              |
+|-----------------|-----------------------------------------------------------------------------------------|
+|`evaluate`       |Prompts for an expression that the LSP should evaluate in the context of the current file. Value can be passed also directly or via visual selection, instead of prompting, and in the latter case can be substituted directly|
 
 ### `idris2.hover` module
 |Function     |Description                                                    |

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -185,9 +185,24 @@ for the namespace. The default options are: >
 ===============================================================================
 Lua module: idris2.repl                                           *idris2.repl*
 
-evaluate()                                             *idris2.repl.evaluate()*
+evaluate({opts})                                       *idris2.repl.evaluate()*
 `evaluate` sends a request to the LSP to evaluate a given expression.
 Before the request asks the user, via an input popup, for the expression to evaulate.
+The optional `expr` option expects a string sends it's value instead of
+prompting the user.
+The optional `visual` flag sends the last visual selection instead of
+prompting the user.
+The optional `sub` flag substitutes the evaluated result to the original
+expression, instead of showing it. It does nothing if `visual` is not enabled.
+prompting the user.
+The default options are: >
+  {
+    expr = '', -- Uses the provided string instead of the prompt
+    sub = false, -- Substitute the expression with the evaluation
+    visual = false, -- Uses the last selected text instead of the prompt
+    virtual = false, -- Prints the evaluated expression as virtual text at the
+                        end of the line
+  }
 
 ===============================================================================
 Lua module: idris2.code_action                               *idris2.code_action*

--- a/lua/idris2/repl.lua
+++ b/lua/idris2/repl.lua
@@ -23,29 +23,81 @@ local term_popup_options = {
   },
 }
 
-function M.menu_handler(expression)
+function M.menu_handler(expression, opts)
+  local opts = opts or {}
   return function (err, result, ctx, config)
     if err ~= nil then
       vim.notify(err, vim.log.levels.ERROR)
+      return
+    end
+
+    if opts.virtual then
+      print(vim.inspect(opts))
+      local ns = vim.api.nvim_create_namespace('nvim-lsp-virtual-hl')
+      vim.api.nvim_buf_set_extmark(opts.s_start[1], ns, opts.s_start[2] - 1, opts.s_start[3] - 1, {
+        id = 1,
+        virt_text = {{ '> ' .. expression .. ' => ' .. result, 'Comment'}},
+        virt_text_pos = 'eol',
+      })
     else
       vim.notify(result, vim.log.levels.INFO)
     end
   end
 end
 
-function M.evaluate()
-  local input = Input(term_popup_options, {
-    prompt = '> ',
-    default_value = '',
-    on_submit = function(value)
-      local params = {
-        command = 'repl',
-        arguments = { value },
-      }
-      vim.lsp.buf_request(0, 'workspace/executeCommand', params, M.menu_handler(value))
-    end,
-  })
-  input:mount()
+function M.evaluate(opts)
+  local opts = opts or {}
+  if opts.expr ~= nil then
+    local params = {
+      command = 'repl',
+      arguments = { opts.expr },
+    }
+    vim.lsp.buf_request(0, 'workspace/executeCommand', params, M.menu_handler(opts.expr, opts))
+  else
+    local input = Input(term_popup_options, {
+      prompt = '> ',
+      default_value = '',
+      on_submit = function(value)
+        local params = {
+          command = 'repl',
+          arguments = { value },
+        }
+        vim.lsp.buf_request(0, 'workspace/executeCommand', params, M.menu_handler(value, opts))
+      end,
+    })
+    input:mount()
+  end
+end
+
+local function get_visual_selection()
+  local s_start = vim.fn.getpos("'<")
+  local s_end = vim.fn.getpos("'>")
+  local n_lines = math.abs(s_end[2] - s_start[2]) + 1
+  local lines = vim.api.nvim_buf_get_lines(0, s_start[2] - 1, s_end[2], false)
+  if vim.tbl_isempty(lines) then
+    return nil, nil, nil
+  end
+  lines[1] = string.sub(lines[1], s_start[3], -1)
+  if n_lines == 1 then
+    lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3] - s_start[3] + 1)
+  else
+    lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3])
+  end
+  return s_start, s_end, table.concat(lines, '\n')
+end
+
+function M.visual_evaluate(opts)
+  local s_start, s_end, sel = get_visual_selection()
+  local opts = vim.tbl_deep_extend('force', { s_start = s_start, s_end = s_end }, opts or {})
+  if sel ~= nil and sel ~= '' then
+    local params = {
+      command = 'repl',
+      arguments = { sel }
+    }
+    vim.lsp.buf_request(0, 'workspace/executeCommand', params, M.menu_handler(sel, opts))
+  else
+    vim.notify('Nothing selected to evaluate', vim.log.levels.ERROR)
+  end
 end
 
 return M


### PR DESCRIPTION
More features for the evaluate at REPL command:
- Use a string instead of a prompt with the `expr` option;
- Use the last visual selection instead of prompt with the `visual` option;
- Substitute instead of printing with both `visual` and `sub` options;
- Print the result via virtual text at the end of line with the `virtual` option.