### PR TITLE
fix hook for adding a file

### DIFF
--- a/lua/idris2/init.lua
+++ b/lua/idris2/init.lua
@@ -65,15 +65,13 @@ local function setup_lsp()
 	-- as read-only with no ipkg since they should not be compiled. This patches
 	-- the function that adds files to the attached LSP instance, so that it
 	-- doesn't add Idris2 files in the installation prefix (idris2 --prefix)
-	local old_try_add = nvim_lsp.idris2_lsp.manager.try_add
+	local old_add = nvim_lsp.idris2_lsp.manager.add
 	local flag, res = pcall(function()
 		return vim.split(vim.fn.system({ "idris2", "--prefix" }), "\n")[1]
 	end)
-	nvim_lsp.idris2_lsp.manager.try_add = function(bufnr)
-		bufnr = bufnr or vim.api.nvim_get_current_buf()
-		local path = vim.api.nvim_buf_get_name(bufnr)
-		if not flag or not vim.startswith(path, res) then
-			old_try_add(bufnr)
+	nvim_lsp.idris2_lsp.manager.add = function(self, root_dir, single_file, bufnr)
+		if not flag or not vim.startswith(root_dir, res) then
+			old_add(self, root_dir, single_file, bufnr)
 		end
 	end
 end


### PR DESCRIPTION
https://github.com/neovim/nvim-lspconfig/pull/2775 broke this plugin because the `try_add` and related functions were defined/called with the `:` accessor syntax which means that when overriding them as anonymous functions the `self` argument needs to be added. In addition to adding the `self` argument, I realized that some of the work done by the plugin was being done by the `lspconfig` `try_add` function anyway, so hooking in at the `add` function saves a bit of code.