### PR TITLE
Add 'Type-check name' from the book

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ vim.cmd [[nnoremap <Leader>cs <Cmd>lua require('idris2.code_action').case_split(
 |`stop`   |Stop automatic requests of semantic groups on save     |
 
 ### `idris2.metavars` module
-|Function     |Description                                             |
-|-------------|--------------------------------------------------------|
-|`request_all`|Open a popup with all the metavars and jump on selection|
-|`goto_next`  |Jumps to the next metavar in the buffer                 |
-|`goto_prev`  |Jumps to the previous metavar in the buffer             |
+|Function     |Description                                                                                  |
+|-------------|---------------------------------------------------------------------------------------------|
+|`request_all`|Open a popup with all the metavars and jump on selection                                     |
+|`type_check` |Open a popup with the type of the metavar under the cursor, and the types of all related vars|
+|`goto_next`  |Jumps to the next metavar in the buffer                                                      |
+|`goto_prev`  |Jumps to the previous metavar in the buffer                                                  |
 
 ### `idris2.browse` module
 |Function     |Description                                                                          |

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -151,6 +151,17 @@ server. The default options are: >
     popup = false, -- Closes the menu when out of focus
   }
 
+type_check({opts})                                idris2.metavars.type_check()
+type_check tries to create a popup containing:
+1. The names and types of the premises
+2. A seperator line
+3. The name and type of the metavariable the cursor is over
+
+The default options are:
+  {
+    popup = true, -- Closes the menu when out of focus
+  }
+
 goto_next()                                       *idris2.metavars.goto_next()*
 `goto_next` tries to jump to the next metavar in the current buffer, cycling
 back to the start if the cursor is after the last metavar.

--- a/lua/idris2/code_action.lua
+++ b/lua/idris2/code_action.lua
@@ -159,20 +159,6 @@ function M.expr_search_hints()
 end
 
 function M.setup()
-  local custom_handler = plugin_config.options.code_action_post_hook
-  if custom_handler == nil then
-    return
-  end
-  local ui_select = vim.ui.select
-  vim.ui.select = function(action_tuples, opts, on_user_choice)
-    local function on_choice(action_tuple)
-      on_user_choice(action_tuple)
-      if opts.kind == 'codeaction' and action_tuple ~= nil then
-        custom_handler(action_tuple[2])
-      end
-    end
-    ui_select(action_tuples, opts, on_choice)
-  end
 end
 
 return M


### PR DESCRIPTION
The book 'Type-driven Development with Idris' by Edwin Brady
describes a 'Type-check name' command in the Atom extension
for Idris (called with Ctrl-Alt-T).

It is described as showing the type of a hole, and the types
of all the variables associated with it.

It seemed useful to me but there wasn't tooling for it, so
I have attempted to replicate its functionality as close
to the description in the book as I could get it.