### PR TITLE
Updates for upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require('idris2').setup({})
 **NOTE: This is the only line of code necessary for setup, do not also add lines for `nvim-lspconfig` because the server setup is already handled by the plugin.**
 
 ## Configuration
-The options shown below are the defaults. You only need to pass the keys to the setup function that you want to be changed, because the defaults are applied for keys that are not provided. 
+The options shown below are the defaults. You only need to pass the keys to the setup function that you want to be changed, because the defaults are applied for keys that are not provided.
 
 ```lua
 local opts = {
@@ -164,6 +164,7 @@ vim.cmd [[nnoremap <Leader>cs <Cmd>lua require('idris2.code_action').case_split(
 |-------------|---------------------------------------------------------------|
 |`open_split` |Show hovers in a persistent split window, can show full history|
 |`close_split`|Show hovers in the default popup                               |
+|`hover`      |Perform the hovering action (useful when `vim.lsp.buf.hover()` does not work anymore)|
 
 ### `idris2.code_action` module
 |Function           |Description                                                                       |

--- a/doc/idris2-nvim.txt
+++ b/doc/idris2-nvim.txt
@@ -85,7 +85,7 @@ table expected by the `setup` function, with the default values: >
 
 If you want to perform some action after the LSP completes a Code Action,
 you can register a hook (a function to be called when any code action is
-completed). 
+completed).
 
 Your function will be called with the chosen code action as its only parameter.
 This action parameter has a `title` and optionally an `edit`. The details of these
@@ -170,6 +170,11 @@ replacing previous hovers.
 
 close_split()                                      *idris2.hover.close_split()*
 `close_split` restores the default handler for LSP hover actions.
+
+hover({split})                                     *idris2.hover.hover()*
+`hover` forces the hovering action on the current file position. When optional
+`split` argument is given, this forces to open or close the split,
+correspondingly.
 
 ===============================================================================
 Lua module: idris2.browse                                         *idris2.browse*

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -55,6 +55,13 @@ function M.handler(err, result, ctx, cfg)
   end
 end
 
+-- When split is not given, use the current state of split, else set it accordingly
+function M.hover(split)
+  if split == true then M.open_split() elseif split == false then M.close_split() end
+  local params = vim.lsp.util.make_position_params(vim.api.nvim_get_current_win(), "utf-8")
+  vim.lsp.buf_request(0, 'textDocument/hover', params, M.handler)
+end
+
 function M.setup()
   local ft = vim.bo.filetype
   M.res_split = Split({

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -8,7 +8,7 @@ M.res_split = nil
 
 function M.handler(err, result, ctx, cfg)
   if err ~= nil then
-    vim.notify(err, vim.log.levels.ERROR)
+    vim.notify(err.message, vim.log.levels.ERROR)
     return
   end
   if not result then

--- a/lua/idris2/hover.lua
+++ b/lua/idris2/hover.lua
@@ -28,8 +28,7 @@ function M.handler(err, result, ctx, cfg)
   if config.split_open then
     vim.api.nvim_buf_set_option(M.res_split.bufnr, 'modifiable', true)
 
-    local lines = vim.split(result.contents.value, '\n')
-    lines = vim.lsp.util.trim_empty_lines(lines)
+    local lines = vim.split(result.contents.value, '\n', {trimempty=true})
     table.insert(lines, 1, '')
     table.insert(lines, '')
 

--- a/lua/idris2/semantic.lua
+++ b/lua/idris2/semantic.lua
@@ -52,8 +52,8 @@ function M.full(err, result, ctx, cfg)
     local token_type = token_types[data[i + 3] + 1]
 
     local line = vim.api.nvim_buf_get_lines(bufnr, prev_line, prev_line + 1, false)[1]
-    local byte_start = vim.str_byteindex(line, prev_start)
-    local byte_end = vim.str_byteindex(line, prev_start + data[i + 2])
+    local byte_start = vim.str_byteindex(line, "utf-8", prev_start)
+    local byte_end = vim.str_byteindex(line, "utf-8", prev_start + data[i + 2])
     vim.api.nvim_buf_add_highlight(bufnr, ns, 'LspSemantic_' .. token_type, prev_line, byte_start, byte_end)
   end
   vim.notify(vim.fn.expand('%:t') .. ' semantically highlighted', vim.log.levels.INFO)


### PR DESCRIPTION
Some functions or their call variants were deprecated + functionality of hovering *with* split does not work on newer upstream anymore due to intentional breaking change, so I suggest to add new function to be used instead of an old `vim.lsp.buf.hover()` call. This is safe to use it anytime, but definitely must be used on Neovim >=0.11 for the old functionality. Also, I found and fixed a bug of wrong error message reporting when LSP request is not successful (i.e. must never happen normally).