### PR TITLE
Migrate to vim.lsp.config/enable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Easy setup and extra features for the native LSP client and the Idris2 LSP serve
 
 ## Prerequisites
 
-- `neovim 0.5+`
+- `neovim 0.11+`
 - `nvim-lspconfig`
 - `idris2`
 - `idris2-lsp`


### PR DESCRIPTION
Fixes #42

- Replaced deprecated `nvim-lspconfig` API (`require('lspconfig').idris2_lsp.setup()`) with native Neovim LSP configuration using `vim.lsp.config()` and `vim.lsp.enable()`
- Updated `root_dir` function signature to match new API expectations. Mostly the same as in `nvim-lspconfig` `idris2_lsp` configuration, just with the warning.
- Removed workaround for not attaching LSP to read-only files in the Idris2 installation prefix. This workaround seems counter intuitive to me because as far as I can understand it disables LSP for installed libraries. If it is still desirable, I could try to find a way to reintroduce it with the new API.